### PR TITLE
Raytracing ue 5.1 dx12 max vertice on RayTracingGeo segment

### DIFF
--- a/Source/ProceduralLandscape/Private/Component/GeoClipmapMeshComponent.cpp
+++ b/Source/ProceduralLandscape/Private/Component/GeoClipmapMeshComponent.cpp
@@ -163,12 +163,12 @@ public:
 
 static void ConvertProcMeshToDynMeshVertex(FDynamicMeshVertex& Vert, const FGeoCProcMeshVertex& ProcVert)
 {
-	Vert.Position = ProcVert.Position;
+	Vert.Position = FVector3f(ProcVert.Position);
 	Vert.Color = ProcVert.Color;
-	Vert.TextureCoordinate[0] = ProcVert.UV0;
-	Vert.TextureCoordinate[1] = ProcVert.UV1;
-	Vert.TextureCoordinate[2] = ProcVert.UV2;
-	Vert.TextureCoordinate[3] = ProcVert.UV3;
+	Vert.TextureCoordinate[0] = FVector2f(ProcVert.UV0);
+	Vert.TextureCoordinate[1] = FVector2f(ProcVert.UV1);
+	Vert.TextureCoordinate[2] = FVector2f(ProcVert.UV2);
+	Vert.TextureCoordinate[3] = FVector2f(ProcVert.UV3);
 	Vert.TangentX = ProcVert.Tangent.TangentX;
 	Vert.TangentZ = ProcVert.Normal;
 	Vert.TangentZ.Vector.W = ProcVert.Tangent.bFlipTangentY ? -127 : 127;
@@ -262,6 +262,7 @@ public:
 						FRayTracingGeometrySegment Segment;
 						Segment.VertexBuffer = NewSection->VertexBuffers.PositionVertexBuffer.VertexBufferRHI;
 						Segment.NumPrimitives = NewSection->RayTracingGeometry.Initializer.TotalPrimitiveCount;
+						Segment.MaxVertices = Segment.VertexBuffer->GetSize();
 						NewSection->RayTracingGeometry.Initializer.Segments.Add(Segment);
 
 						//#dxr_todo: add support for segments?
@@ -334,7 +335,7 @@ public:
 					ConvertProcMeshToDynMeshVertex(Vertex, ProcVert);
 
 					Section->VertexBuffers.PositionVertexBuffer.VertexPosition(i) = Vertex.Position;
-					Section->VertexBuffers.StaticMeshVertexBuffer.SetVertexTangents(i, Vertex.TangentX.ToFVector(), Vertex.GetTangentY(), Vertex.TangentZ.ToFVector());
+					Section->VertexBuffers.StaticMeshVertexBuffer.SetVertexTangents(i, FVector3f(Vertex.TangentX.ToFVector()), Vertex.GetTangentY(), FVector3f(Vertex.TangentZ.ToFVector()));
 					Section->VertexBuffers.StaticMeshVertexBuffer.SetVertexUV(i, 0, Vertex.TextureCoordinate[0]);
 					Section->VertexBuffers.StaticMeshVertexBuffer.SetVertexUV(i, 1, Vertex.TextureCoordinate[1]);
 					Section->VertexBuffers.StaticMeshVertexBuffer.SetVertexUV(i, 2, Vertex.TextureCoordinate[2]);
@@ -1128,7 +1129,7 @@ bool UGeoClipmapMeshComponent::GetPhysicsTriMeshData(struct FTriMeshCollisionDat
 			// Copy vert data
 			for (int32 VertIdx = 0; VertIdx < Section.ProcVertexBuffer.Num(); VertIdx++)
 			{
-				CollisionData->Vertices.Add(Section.ProcVertexBuffer[VertIdx].Position);
+				CollisionData->Vertices.Add(FVector3f(Section.ProcVertexBuffer[VertIdx].Position));
 
 				// Copy UV if desired
 				if (bCopyUVs)


### PR DESCRIPTION
Sets maxvertices to vertex buffer size, and changes vertex positions use Vertex3f to match with DynamicMeshBuilder expecting floats for texturecoordinates.
